### PR TITLE
Back-port the use of Polymer to this older version of Leaflet

### DIFF
--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -1,3 +1,5 @@
+/* global Polymer */
+/* eslint no-undef: "error" */
 /*
  * L.Control.Attribution is used for displaying attribution on the map (added by default).
  */
@@ -82,7 +84,7 @@ L.Control.Attribution = L.Control.extend({
 			prefixAndAttribs.push(attribs.join(', '));
 		}
 
-		this._container.innerHTML = prefixAndAttribs.join(' | ');
+		Polymer.dom(this._container).innerHTML = prefixAndAttribs.join(' | ');
 	}
 });
 

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -102,7 +102,7 @@ L.Control.Layers = L.Control.extend({
 		this._separator = L.DomUtil.create('div', className + '-separator', form);
 		this._overlaysList = L.DomUtil.create('div', className + '-overlays', form);
 
-		container.appendChild(form);
+		Polymer.dom(container).appendChild(form);
 	},
 
 	_addLayer: function (layer, name, overlay) {
@@ -196,18 +196,18 @@ L.Control.Layers = L.Control.extend({
 		L.DomEvent.on(input, 'click', this._onInputClick, this);
 
 		var name = document.createElement('span');
-		name.innerHTML = ' ' + obj.name;
+		Polymer.dom(name).innerHTML = ' ' + obj.name;
 
 		// Helps from preventing layer control flicker when checkboxes are disabled
 		// https://github.com/Leaflet/Leaflet/issues/2771
 		var holder = document.createElement('div');
 
-		label.appendChild(holder);
-		holder.appendChild(input);
-		holder.appendChild(name);
+		Polymer.dom(label).appendChild(holder);
+		Polymer.dom(holder).appendChild(input);
+		Polymer.dom(holder).appendChild(name);
 
 		var container = obj.overlay ? this._overlaysList : this._baseLayersList;
-		container.appendChild(label);
+		Polymer.dom(container).appendChild(label);
 
 		return label;
 	},

--- a/src/control/Control.Scale.js
+++ b/src/control/Control.Scale.js
@@ -1,3 +1,5 @@
+/* global Polymer */
+/* eslint no-undef: "error" */
 /*
  * L.Control.Scale is used for displaying metric/imperial scale on the map.
  */
@@ -80,8 +82,8 @@ L.Control.Scale = L.Control.extend({
 	},
 
 	_updateScale: function (scale, text, ratio) {
-		scale.style.width = Math.round(this.options.maxWidth * ratio) + 'px';
-		scale.innerHTML = text;
+		Polymer.dom(scale).node.style.width = Math.round(this.options.maxWidth * ratio) + 'px';
+		Polymer.dom(scale).innerHTML = text;
 	},
 
 	_getRoundNum: function (num) {

--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -1,3 +1,5 @@
+/* global Polymer */
+/* eslint no-undef: "error" */
 /*
  * L.Control.Zoom is used for the default zoom buttons on the map.
  */
@@ -57,9 +59,9 @@ L.Control.Zoom = L.Control.extend({
 
 	_createButton: function (html, title, className, container, fn) {
 		var link = L.DomUtil.create('a', className, container);
-		link.innerHTML = html;
-		link.href = '#';
-		link.title = title;
+		Polymer.dom(link).innerHTML = html;
+		Polymer.dom(link).node.href = '#';
+		Polymer.dom(link).node.title = title;
 
 		L.DomEvent
 		    .on(link, 'mousedown dblclick', L.DomEvent.stopPropagation)

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -47,9 +47,9 @@ L.Control = L.Class.extend({
 		L.DomUtil.addClass(container, 'leaflet-control');
 
 		if (pos.indexOf('bottom') !== -1) {
-			corner.insertBefore(container, corner.firstChild);
+			Polymer.dom(corner).insertBefore(container, Polymer.dom(corner).firstChild);
 		} else {
-			corner.appendChild(container);
+			Polymer.dom(corner).appendChild(container);
 		}
 
 		return this;

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -35,7 +35,7 @@ L.ImageOverlay = L.Layer.extend({
 			this.addInteractiveTarget(this._image);
 		}
 
-		this.getPane().appendChild(this._image);
+		Polymer.dom(this.getPane()).appendChild(this._image);
 		this._reset();
 	},
 

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -46,7 +46,7 @@ L.Popup = L.Layer.extend({
 		}
 
 		clearTimeout(this._removeTimeout);
-		this.getPane().appendChild(this._container);
+		Polymer.dom(this.getPane()).appendChild(this._container);
 		this.update();
 
 		if (map._fadeAnimated) {
@@ -182,12 +182,12 @@ L.Popup = L.Layer.extend({
 		var content = (typeof this._content === 'function') ? this._content(this._source || this) : this._content;
 
 		if (typeof content === 'string') {
-			node.innerHTML = content;
+			Polymer.dom(node).innerHTML = content;
 		} else {
-			while (node.hasChildNodes()) {
-				node.removeChild(node.firstChild);
+			while (Polymer.dom(node).hasChildNodes()) {
+				Polymer.dom(node).removeChild(Polymer.dom(node).firstChild);
 			}
-			node.appendChild(content);
+			Polymer.dom(node).appendChild(content);
 		}
 		this.fire('contentupdate');
 	},

--- a/src/layer/marker/DivIcon.js
+++ b/src/layer/marker/DivIcon.js
@@ -1,3 +1,5 @@
+/* global Polymer */
+/* eslint no-undef: "error" */
 /*
  * L.DivIcon is a lightweight HTML-based icon class (as opposed to the image-based L.Icon)
  * to use with L.Marker.
@@ -20,10 +22,11 @@ L.DivIcon = L.Icon.extend({
 		var div = (oldIcon && oldIcon.tagName === 'DIV') ? oldIcon : document.createElement('div'),
 		    options = this.options;
 
-		div.innerHTML = options.html !== false ? options.html : '';
+		Polymer.dom(div).innerHTML = options.html !== false ? options.html : '';
 
 		if (options.bgPos) {
-			div.style.backgroundPosition = (-options.bgPos.x) + 'px ' + (-options.bgPos.y) + 'px';
+			var bgPos = L.point(options.bgPos);
+			Polymer.dom(div).style.backgroundPosition = (-bgPos.x) + 'px ' + (-bgPos.y) + 'px';
 		}
 		this._setIconStyles(div, 'icon');
 

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -159,10 +159,10 @@ L.Marker = L.Layer.extend({
 
 
 		if (addIcon) {
-			this.getPane().appendChild(this._icon);
+			Polymer.dom(this.getPane()).appendChild(this._icon);
 		}
 		if (newShadow && addShadow) {
-			this.getPane('shadowPane').appendChild(this._shadow);
+			Polymer.dom(this.getPane('shadowPane')).appendChild(this._shadow);
 		}
 	},
 

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -201,7 +201,7 @@ L.GridLayer = L.Layer.extend({
 			this._updateOpacity();
 		}
 
-		this.getPane().appendChild(this._container);
+		Polymer.dom(this.getPane()).appendChild(this._container);
 	},
 
 	_updateLevels: function () {
@@ -482,7 +482,7 @@ L.GridLayer = L.Layer.extend({
 				this._addTile(queue[i], fragment);
 			}
 
-			this._level.el.appendChild(fragment);
+			Polymer.dom(this._level.el).appendChild(fragment);
 		}
 	},
 
@@ -597,7 +597,7 @@ L.GridLayer = L.Layer.extend({
 			current: true
 		};
 
-		container.appendChild(tile);
+		Polymer.dom(container).appendChild(tile);
 		this.fire('tileloadstart', {
 			tile: tile,
 			coords: coords

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -25,7 +25,7 @@ L.Renderer = L.Layer.extend({
 			}
 		}
 
-		this.getPane().appendChild(this._container);
+		Polymer.dom(this.getPane()).appendChild(this._container);
 		this._update();
 	},
 

--- a/src/layer/vector/SVG.VML.js
+++ b/src/layer/vector/SVG.VML.js
@@ -1,3 +1,5 @@
+/* global Polymer */
+/* eslint no-undef: "error" */
 /*
  * Vector rendering for IE7-8 through VML.
  * Thanks to Dmitry Baranovsky and his Raphael library for inspiration!
@@ -6,12 +8,12 @@
 L.Browser.vml = !L.Browser.svg && (function () {
 	try {
 		var div = document.createElement('div');
-		div.innerHTML = '<v:shape adj="1"/>';
+		Polymer.dom(div).innerHTML = '<v:shape adj="1"/>';
 
-		var shape = div.firstChild;
-		shape.style.behavior = 'url(#default#VML)';
+		var shape = Polymer.dom(div).firstChild;
+		Polymer.dom(shape).node.style.behavior = 'url(#default#VML)';
 
-		return shape && (typeof shape.adj === 'object');
+		return shape && (typeof Polymer.dom(shape).node.adj === 'object');
 
 	} catch (e) {
 		return false;
@@ -38,14 +40,14 @@ L.SVG.include(!L.Browser.vml ? {} : {
 		container.coordsize = '1 1';
 
 		layer._path = L.SVG.create('path');
-		container.appendChild(layer._path);
+		Polymer.dom(container).appendChild(layer._path);
 
 		this._updateStyle(layer);
 	},
 
 	_addPath: function (layer) {
 		var container = layer._container;
-		this._container.appendChild(container);
+		Polymer.dom(this._container).appendChild(container);
 
 		if (layer.options.interactive) {
 			layer.addInteractiveTarget(container);
@@ -70,7 +72,7 @@ L.SVG.include(!L.Browser.vml ? {} : {
 		if (options.stroke) {
 			if (!stroke) {
 				stroke = layer._stroke = L.SVG.create('stroke');
-				container.appendChild(stroke);
+                                Polymer.dom(container).appendChild(stroke);
 			}
 			stroke.weight = options.weight + 'px';
 			stroke.color = options.color;
@@ -87,20 +89,20 @@ L.SVG.include(!L.Browser.vml ? {} : {
 			stroke.joinstyle = options.lineJoin;
 
 		} else if (stroke) {
-			container.removeChild(stroke);
+			Polymer.dom(container).removeChild(stroke);
 			layer._stroke = null;
 		}
 
 		if (options.fill) {
 			if (!fill) {
 				fill = layer._fill = L.SVG.create('fill');
-				container.appendChild(fill);
+				Polymer.dom(container).appendChild(fill);
 			}
 			fill.color = options.fillColor || options.color;
 			fill.opacity = options.fillOpacity;
 
 		} else if (fill) {
-			container.removeChild(fill);
+			Polymer.dom(container).removeChild(fill);
 			layer._fill = null;
 		}
 	},

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -8,10 +8,10 @@ L.SVG = L.Renderer.extend({
 		this._container = L.SVG.create('svg');
 
 		// makes it possible to click through svg root; we'll reset it back in individual paths
-		this._container.setAttribute('pointer-events', 'none');
+		Polymer.dom(this._container).setAttribute('pointer-events', 'none');
 
 		this._rootGroup = L.SVG.create('g');
-		this._container.appendChild(this._rootGroup);
+		Polymer.dom(this._container).appendChild(this._rootGroup);
 	},
 
 	_update: function () {
@@ -26,13 +26,13 @@ L.SVG = L.Renderer.extend({
 		// set size of svg-container if changed
 		if (!this._svgSize || !this._svgSize.equals(size)) {
 			this._svgSize = size;
-			container.setAttribute('width', size.x);
-			container.setAttribute('height', size.y);
+			Polymer.dom(container).setAttribute('width', size.x);
+			Polymer.dom(container).setAttribute('height', size.y);
 		}
 
 		// movement: update container viewBox so that we don't have to change coordinates of individual layers
 		L.DomUtil.setPosition(container, b.min);
-		container.setAttribute('viewBox', [b.min.x, b.min.y, size.x, size.y].join(' '));
+		Polymer.dom(container).setAttribute('viewBox', [b.min.x, b.min.y, size.x, size.y].join(' '));
 	},
 
 	// methods below are called by vector layers implementations
@@ -52,7 +52,7 @@ L.SVG = L.Renderer.extend({
 	},
 
 	_addPath: function (layer) {
-		this._rootGroup.appendChild(layer._path);
+		Polymer.dom(this._rootGroup).appendChild(layer._path);
 		layer.addInteractiveTarget(layer._path);
 	},
 
@@ -73,36 +73,36 @@ L.SVG = L.Renderer.extend({
 		if (!path) { return; }
 
 		if (options.stroke) {
-			path.setAttribute('stroke', options.color);
-			path.setAttribute('stroke-opacity', options.opacity);
-			path.setAttribute('stroke-width', options.weight);
-			path.setAttribute('stroke-linecap', options.lineCap);
-			path.setAttribute('stroke-linejoin', options.lineJoin);
+			Polymer.dom(path).setAttribute('stroke', options.color);
+			Polymer.dom(path).setAttribute('stroke-opacity', options.opacity);
+			Polymer.dom(path).setAttribute('stroke-width', options.weight);
+			Polymer.dom(path).setAttribute('stroke-linecap', options.lineCap);
+			Polymer.dom(path).setAttribute('stroke-linejoin', options.lineJoin);
 
 			if (options.dashArray) {
-				path.setAttribute('stroke-dasharray', options.dashArray);
+				Polymer.dom(path).setAttribute('stroke-dasharray', options.dashArray);
 			} else {
-				path.removeAttribute('stroke-dasharray');
+				Polymer.dom(path).removeAttribute('stroke-dasharray');
 			}
 
 			if (options.dashOffset) {
-				path.setAttribute('stroke-dashoffset', options.dashOffset);
+				Polymer.dom(path).setAttribute('stroke-dashoffset', options.dashOffset);
 			} else {
-				path.removeAttribute('stroke-dashoffset');
+				Polymer.dom(path).removeAttribute('stroke-dashoffset');
 			}
 		} else {
-			path.setAttribute('stroke', 'none');
+			Polymer.dom(path).setAttribute('stroke', 'none');
 		}
 
 		if (options.fill) {
-			path.setAttribute('fill', options.fillColor || options.color);
-			path.setAttribute('fill-opacity', options.fillOpacity);
-			path.setAttribute('fill-rule', options.fillRule || 'evenodd');
+			Polymer.dom(path).setAttribute('fill', options.fillColor || options.color);
+			Polymer.dom(path).setAttribute('fill-opacity', options.fillOpacity);
+			Polymer.dom(path).setAttribute('fill-rule', options.fillRule || 'evenodd');
 		} else {
-			path.setAttribute('fill', 'none');
+			Polymer.dom(path).setAttribute('fill', 'none');
 		}
 
-		path.setAttribute('pointer-events', options.pointerEvents || (options.interactive ? 'visiblePainted' : 'none'));
+		Polymer.dom(path).setAttribute('pointer-events', options.pointerEvents || (options.interactive ? 'visiblePainted' : 'none'));
 	},
 
 	_updatePoly: function (layer, closed) {
@@ -125,7 +125,7 @@ L.SVG = L.Renderer.extend({
 	},
 
 	_setPath: function (layer, path) {
-		layer._path.setAttribute('d', path);
+		Polymer.dom(layer._path).setAttribute('d', path);
 	},
 
 	// SVG does not have the concept of zIndex so we resort to changing the DOM order of elements

--- a/src/map/anim/Map.ZoomAnimation.js
+++ b/src/map/anim/Map.ZoomAnimation.js
@@ -1,3 +1,5 @@
+/* global Polymer */
+/* eslint no-undef: "error" */
 /*
  * Extends L.Map to handle zoom animations.
  */
@@ -31,7 +33,7 @@ L.Map.include(!zoomAnimated ? {} : {
 	_createAnimProxy: function () {
 
 		var proxy = this._proxy = L.DomUtil.create('div', 'leaflet-proxy leaflet-zoom-animated');
-		this._panes.mapPane.appendChild(proxy);
+		Polymer.dom(this._panes.mapPane).appendChild(proxy);
 
 		this.on('zoomanim', function (e) {
 			var prop = L.DomUtil.TRANSFORM,


### PR DESCRIPTION
This update is applied to an earlier development version of Leaflet (v1.0.0-beta.1 tag) which should work with MapML current code. Had tried to upgrade MapML code to use the Leaflet v1.0.0.rc1+ code, which was not working properly, then tried v1.0.0.rc1, which still did not work, so now trying to 'go back' to last year's Leaflet 1.0.0.beta1 release, which did / does work with MapML code. The objective will be to test MapML code in the Leaflet test environment.  Unfortunately, it seems like it will be difficult to test the Custom Element using the Leaflet test environment, because the polymer code is done using HTML Imports, and is not written like a classic JavaScript library which seems is not expected by Karma.  TBD
